### PR TITLE
Splitting navbar helper into independent header and collapse elements

### DIFF
--- a/lib/bootstrap-navbar/helpers/bootstrap3.rb
+++ b/lib/bootstrap-navbar/helpers/bootstrap3.rb
@@ -1,9 +1,7 @@
 module BootstrapNavbar::Helpers::Bootstrap3
   def navbar(options = {}, &block)
     container = options.has_key?(:container) ? options[:container] : true
-    navbar_content =
-      header(options.delete(:brand), options.delete(:brand_link)) <<
-      collapsable(&block)
+    navbar_content = capture(&block)
     wrapper options do
       if container
         container(navbar_content)
@@ -11,6 +9,14 @@ module BootstrapNavbar::Helpers::Bootstrap3
         navbar_content
       end
     end
+  end
+
+  def navbar_header(options = {}, &block)
+    header(options.delete(:brand), options.delete(:brand_link), &block)
+  end
+
+  def navbar_collapse(&block)
+    collapsable(&block)
   end
 
   def navbar_group(options = {}, &block)
@@ -123,7 +129,7 @@ HTML
 HTML
   end
 
-  def header(brand, brand_link)
+  def header(brand, brand_link, &block)
     prepare_html <<-HTML.chomp!
 <div class="navbar-header">
   <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapsable">
@@ -133,6 +139,7 @@ HTML
     <span class="icon-bar"></span>
   </button>
   #{brand_link brand, brand_link unless brand.nil?}
+  #{capture(&block) if block_given?}
 </div>
 HTML
   end

--- a/spec/bootstrap-navbar/helpers/bootstrap3_spec.rb
+++ b/spec/bootstrap-navbar/helpers/bootstrap3_spec.rb
@@ -31,19 +31,7 @@ describe BootstrapNavbar::Helpers::Bootstrap3 do
     context 'without parameters' do
       it 'generates the correct HTML' do
         with_all_3_dot_x_versions do
-          expect(renderer.navbar { 'foo' }).to have_tag(:nav, with: { class: 'navbar navbar-default', role: 'navigation' }) do
-            with_tag :div, with: { class: 'container' } do
-              with_tag :div, with: { class: 'navbar-header' } do
-                with_tag :button, with: { type: 'button', class: 'navbar-toggle', :'data-toggle' => 'collapse', :'data-target' => '#navbar-collapsable' } do
-                  with_tag :span, with: { class: 'sr-only' }, text: /Toggle navigation/
-                  3.times do
-                    with_tag :span, with: { class: 'icon-bar' }
-                  end
-                end
-              end
-              with_tag :div, with: { class: 'collapse navbar-collapse', id: 'navbar-collapsable' }, text: /foo/
-            end
-          end
+          expect(renderer.navbar { 'foo' }).to have_tag(:nav, with: { class: 'navbar navbar-default' }, text: /foo/)
         end
       end
     end
@@ -85,13 +73,38 @@ describe BootstrapNavbar::Helpers::Bootstrap3 do
         end
       end
     end
+  end
+
+  describe '#navbar_header' do
+    context 'without parameters' do
+      it 'generates the correct HTML' do
+        with_all_3_dot_x_versions do
+          expect(renderer.navbar_header { 'foo' }).to have_tag(:div, with: { class: 'navbar-header'}, text: /foo/) do
+            with_tag :button, with: { type: 'button', class: 'navbar-toggle', :'data-toggle' => 'collapse', :'data-target' => '#navbar-collapsable' } do
+              with_tag :span, with: { class: 'sr-only' }, text: /Toggle navigation/
+              3.times do
+                with_tag :span, with: { class: 'icon-bar' }
+              end
+            end
+          end
+        end
+      end
+    end
 
     context 'with "brand" and "brank_link" parameters' do
       it 'generates the correct HTML' do
         with_all_3_dot_x_versions do
-          expect(renderer.navbar(brand: 'foo')).to have_tag(:a, with: { href: '/', class: 'navbar-brand' }, text: /foo/)
-          expect(renderer.navbar(brand: 'foo', brand_link: 'http://google.com')).to have_tag(:a, with: { href: 'http://google.com', class: 'navbar-brand' }, text: /foo/)
+          expect(renderer.navbar_header(brand: 'foo')).to have_tag(:a, with: { href: '/', class: 'navbar-brand' }, text: /foo/)
+          expect(renderer.navbar_header(brand: 'foo', brand_link: 'http://google.com')).to have_tag(:a, with: { href: 'http://google.com', class: 'navbar-brand' }, text: /foo/)
         end
+      end
+    end
+  end
+
+  describe '#navbar_collapse' do
+    it 'generates the correct HTML' do
+      with_all_3_dot_x_versions do
+        expect(renderer.navbar_collapse { 'foo' }).to have_tag(:div, with: { class: 'collapse navbar-collapse', id: 'navbar-collapsable' }, text: /foo/)
       end
     end
   end


### PR DESCRIPTION
According to the discussion in #2, I have created separate helper methods for header and collapse blocks inside the navbar.

This allows the users to insert custom text inside the header and also between header and collapse blocks.

Currently I have done it only for bootstrap3 helpers. Can you let me know if this is the right direction, so I can edit the bootstrap2 helpers aswell?
