### PR TITLE
Fix bootstrap4 navbar_dropdown helper

### DIFF
--- a/lib/bootstrap-navbar/helpers/bootstrap4.rb
+++ b/lib/bootstrap-navbar/helpers/bootstrap4.rb
@@ -67,22 +67,18 @@ HTML
 HTML
   end
 
-  def navbar_dropdown(text, target = '', list_item_options = {}, link_options = {}, ul_options = {}, &block)
+  def navbar_dropdown(text, id = '', list_item_options = {}, link_options = {}, &block)
     list_item_options, link_options = list_item_options.dup, link_options.dup
     list_item_options[:class] = [list_item_options[:class], 'nav-item', 'dropdown'].compact.join(' ')
     list_item_attributes = attributes_for_tag(list_item_options)
     link_options[:class] = [link_options[:class], 'nav-link', 'dropdown-toggle'].compact.join(' ')
-    target ||= "navbarDropdownMenuLink#{text}"
+    id ||= "navbarDropdownMenuLink#{text}"
     link_attributes = attributes_for_tag(link_options)
-    ul_options[:class] = [ul_options[:class], 'nav'].compact.join(' ')
-    ul_attributes = attributes_for_tag(ul_options)
     prepare_html <<-HTML.chomp!
 <li#{list_item_attributes}>
-  <a href="#" data-toggle="dropdown" data-target="##{target}"#{link_attributes}>#{text} <b class="caret"></b></a>
-  <div class="collapse" id="#{target}">
-    <ul#{ul_attributes}>
-      #{capture(&block) if block_given?}
-    </ul>
+  <a href="#" data-toggle="dropdown" id="##{id}" aria-haspopup="true" aria-expanded="false" role="button" #{link_attributes}>#{text}</a>
+  <div class="dropdown-menu" aria-labelledby="#{id}">
+    #{capture(&block) if block_given?}
   </div>
 </li>
 HTML

--- a/lib/bootstrap-navbar/helpers/bootstrap4.rb
+++ b/lib/bootstrap-navbar/helpers/bootstrap4.rb
@@ -84,9 +84,8 @@ HTML
 HTML
   end
 
-  def navbar_dropdown_item(text, url = nil, link_options = nil, &block)
-    url ||= '#'
-    link_options = link_options ? link_options.dup : {}
+  def navbar_dropdown_item(text, url = '#', link_options = {}, &block)
+    link_options = link_options.dup
     link_options[:class] = [link_options[:class], 'dropdown-item'].compact
     link_options[:class] << 'active' if current_url_or_sub_url?(url)
     link_options[:class]  = link_options[:class].join(' ')

--- a/lib/bootstrap-navbar/helpers/bootstrap4.rb
+++ b/lib/bootstrap-navbar/helpers/bootstrap4.rb
@@ -84,6 +84,20 @@ HTML
 HTML
   end
 
+  def navbar_dropdown_item(text, url = nil, link_options = nil, &block)
+    url ||= '#'
+    link_options = link_options ? link_options.dup : {}
+    link_options[:class] = [link_options[:class], 'dropdown-item'].compact
+    link_options[:class] << 'active' if current_url_or_sub_url?(url)
+    link_options[:class]  = link_options[:class].join(' ')
+    link_attributes = attributes_for_tag(link_options)
+    prepare_html <<~HTML.chomp!
+      <a href="#{url}"#{link_attributes}>
+        #{text}
+      </a>
+    HTML
+  end
+
   private
 
   def container(&block)


### PR DESCRIPTION
This also adds an `navbar_dropdown_item` helper for the items of a dropdown - obviously.

The helper is necessary, as the item of a dropdown does not use the `navbar-item` class. Instead it uses the `dropdown-item` class.

fixes #14 