### PR TITLE
adding `navbar_dropdown_divider` in BS4 for ease the migration betweeen versions

### DIFF
--- a/lib/bootstrap-navbar/helpers/bootstrap4.rb
+++ b/lib/bootstrap-navbar/helpers/bootstrap4.rb
@@ -97,6 +97,12 @@ HTML
     HTML
   end
 
+  def navbar_dropdown_divider
+    prepare_html <<-HTML.chomp!
+<div class="dropdown-divider"></div>
+HTML
+  end
+
   private
 
   def container(&block)


### PR DESCRIPTION
It is easier to update bootstrap navbar from Bootstrap 3 to Bootstrap 4 when the API is the same. The method `navbar_dropdown_divider` was missing in bootstrap4.rb

There are most likely other things that can be made more consistent between versions. However, this PR focuses only on this specific method.